### PR TITLE
add global queue

### DIFF
--- a/lib/dispatch_stubs.c
+++ b/lib/dispatch_stubs.c
@@ -107,6 +107,36 @@ value ocaml_dispath_queue_finalise(value v_queue)
   CAMLreturn(Val_unit);
 }
 
+value ocaml_dispatch_get_main_queue(value v_unit) {
+  CAMLparam1(v_unit);
+  CAMLlocal1(v_queue);
+  dispatch_queue_t queue = dispatch_get_main_queue();
+  v_queue = caml_alloc_custom(&queue_ops, sizeof(dispatch_queue_t), 0, 1);
+  Queue_val(v_queue) = queue;
+  CAMLreturn(v_queue);
+}
+
+value ocaml_dispatch_get_global_queue(value v_qos) {
+  CAMLparam1(v_qos);
+  CAMLlocal1(v_queue);
+  intptr_t ident;
+
+  if (v_qos == 1) {
+    ident = QOS_CLASS_USER_INTERACTIVE;
+  } else if (v_qos == 3) {
+    ident = QOS_CLASS_USER_INITIATED;
+  } else if (v_qos == 5) {
+    ident = QOS_CLASS_UTILITY;
+  } else {  
+    ident = QOS_CLASS_BACKGROUND;
+  }
+
+  dispatch_queue_t queue = dispatch_get_global_queue(ident, 0);
+  v_queue = caml_alloc_custom(&queue_ops, sizeof(dispatch_queue_t), 0, 1);
+  Queue_val(v_queue) = queue;
+  CAMLreturn(v_queue);
+}
+
 value ocaml_dispatch_queue_create(value v_typ, value v_unit)
 {
   CAMLparam2(v_typ, v_unit);

--- a/lib/queue.ml
+++ b/lib/queue.ml
@@ -1,13 +1,17 @@
 type t
 type typ = Serial | Concurrent
 
-(* external dispatch_main : unit -> t = "ocaml_dispatch_get_main_queue" *)
-(* external dispatch_global : unit -> t = "ocaml_dispatch_get_global_queue" *)
+module Qos = struct
+  type t = Interactive | User_initiated | Utility | Background
+end
+
+external dispatch_main : unit -> t = "ocaml_dispatch_get_main_queue"
+external dispatch_global : Qos.t -> t = "ocaml_dispatch_get_global_queue"
 external dispatch_create : typ -> t = "ocaml_dispatch_queue_create"
 external dispatch_finalise : t -> unit = "ocaml_dispath_queue_finalise"
 
-(* let main = dispatch_main
-let global = dispatch_global *)
+let main = dispatch_main
+let global = dispatch_global
 
 let create ?(typ = Serial) () =
   let t = dispatch_create typ in

--- a/lib/queue.mli
+++ b/lib/queue.mli
@@ -1,6 +1,11 @@
 type t
 type typ = Serial | Concurrent
 
-(* val main : unit -> t
-val global : unit -> t *)
+val main : unit -> t
+
+module Qos : sig
+  type t = Interactive | User_initiated | Utility | Background
+end
+
+val global : Qos.t -> t
 val create : ?typ:typ -> unit -> t


### PR DESCRIPTION
This PR adds the getters for the `main` and `global` queues -- ultimately tasks will end up on on of these queues and the `global` ones can have a quality of services specified (see `Dispatch.Queue.Qos`).