### PR TITLE
add thunks and blocks

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -1,0 +1,14 @@
+type t
+
+external dispatch_block_create : (unit -> unit) -> t
+  = "ocaml_dispatch_block_create"
+
+external dispatch_block_destroy : t -> unit = "ocaml_dispatch_block_destroy"
+external dispatch_block_exec : t -> unit = "ocaml_dispatch_block_exec"
+
+let create thunk =
+  let b = dispatch_block_create thunk in
+  Gc.finalise dispatch_block_destroy b;
+  b
+
+let exec = dispatch_block_exec

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -1,0 +1,8 @@
+type t
+(** The type for dispatch blocks (essentially thunks) *)
+
+val create : (unit -> unit) -> t
+(** [create thunk] makes a new dispatch block *)
+
+val exec : t -> unit
+(** [exec t] executes the block *)

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -9,7 +9,7 @@ let () =
               "-L" ^ C.ocaml_config_var_exn c "standard_library";
               "-lthreadsnat";
               "-lunix";
-              "-ObjC";
+              "-lobjc";
             ];
           cflags = [];
         }

--- a/lib/dispatch.ml
+++ b/lib/dispatch.ml
@@ -1,4 +1,5 @@
 module Queue = Queue
+module Block = Block
 module Io = Io
 module Group = Group
 module Data = Data

--- a/test/dune
+++ b/test/dune
@@ -10,3 +10,7 @@
  (alias runtest)
  (action
   (diff ./text.txt ./text2.txt)))
+
+(test
+ (name main)
+ (libraries dispatch))

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,0 +1,5 @@
+let () =
+  let block1 = Dispatch.Block.create (fun () -> print_endline "Hello") in
+  let block2 = Dispatch.Block.create (fun () -> print_endline "World") in
+  Dispatch.Block.exec block1;
+  Dispatch.Block.exec block2


### PR DESCRIPTION
This allows a user to define a thunk (`unit -> unit`) and wrap it in a "block" -- an Apple extension to C to allow lambda like abstractions.