### PR TITLE
Improve io functions

### DIFF
--- a/lib/dispatch.ml
+++ b/lib/dispatch.ml
@@ -5,6 +5,8 @@ module Group = Group
 module Data = Data
 module Time = Time
 
+external dispatch_main : unit -> unit = "ocaml_dispatch_main"
+
 external dispatch_async : Queue.t -> (unit -> unit) -> unit
   = "ocaml_dispatch_async"
 
@@ -13,3 +15,4 @@ external dispatch_sync : Queue.t -> (unit -> unit) -> unit
 
 let async = dispatch_async
 let sync = dispatch_sync
+let main = dispatch_main

--- a/lib/dispatch_stubs.c
+++ b/lib/dispatch_stubs.c
@@ -35,6 +35,14 @@ void free_callback(value *v_fun)
   caml_stat_free(v_fun);
 }
 
+// ~~~Functions~~~
+value ocaml_dispatch_main(value v_unit) {
+  CAMLparam1(v_unit);
+  // Won't return
+  dispatch_main();
+  CAMLreturn(Val_unit);
+}
+
 // ~~~Block~~~
 static struct custom_operations block_ops = {
     "dispatch.block",

--- a/lib/io.ml
+++ b/lib/io.ml
@@ -1,15 +1,18 @@
 type t
 type typ = Stream | Random
+type err = int
+type handler = err:err -> finished:bool -> Data.t -> unit
 
 external dispatch_io_create : typ -> Unix.file_descr -> Queue.t -> t
   = "ocaml_dispatch_io_create"
 
-(* external dispatch_read : Queue.t -> t -> int -> int -> Group.t -> Data.t -> unit
-  = "ocaml_dispatch_read_bytecode" "ocaml_dispatch_read" *)
-
 external dispatch_with_read :
-  Queue.t -> t -> Group.t -> (Data.t -> unit) -> (unit -> unit) -> unit
+  t -> int -> int -> Queue.t -> (int -> bool -> Data.t -> unit) -> unit
   = "ocaml_dispatch_with_read"
+
+external dispatch_with_write :
+  t -> int -> Data.t -> Queue.t -> (int -> bool -> Data.t -> unit) -> unit
+  = "ocaml_dispatch_with_write"
 
 external dispatch_write : Queue.t -> t -> int -> Group.t -> Data.t -> unit
   = "ocaml_dispatch_write"
@@ -22,12 +25,13 @@ external dispatch_set_low_water : t -> int -> unit
 
 let create typ fd q = dispatch_io_create typ fd q
 
-(* let read queue channel length offset group data =
-  let _ = dispatch_read queue channel length offset group data in
-  () *)
+let with_read ~f ~off ~length ~queue channel =
+  let f' err finished data = f ~err ~finished data in
+  dispatch_with_read channel off length queue f'
 
-let with_read ~f ~err queue channel group =
-  dispatch_with_read queue channel group f err
+let with_write ~f ~off ~data ~queue channel =
+  let f' err finished data = f ~err ~finished data in
+  dispatch_with_write channel off data queue f'
 
 let write queue channel offset group data =
   let _ = dispatch_write queue channel offset group data in

--- a/lib/io.mli
+++ b/lib/io.mli
@@ -1,12 +1,33 @@
 type t
-type typ = Stream | Random  (** GCD IO channels *)
+(** The type of IO Channels *)
+
+type typ =
+  | Stream
+  | Random
+      (** The underlying type of the channel -- with [Random] you can use the
+          file offset to read *)
 
 val create : typ -> Unix.file_descr -> Queue.t -> t
+(** Create a new channel of a particular [typ] from a [Unix.file_descr] *)
 
 (* val read : Queue.t -> t -> int -> int -> Group.t -> Data.t -> unit *)
 
-val with_read :
-  f:(Data.t -> unit) -> err:(unit -> unit) -> Queue.t -> t -> Group.t -> unit
+type err = int
+(** Error type *)
+
+type handler = err:err -> finished:bool -> Data.t -> unit
+(** The type of IO handler *)
+
+val with_read : f:handler -> off:err -> length:err -> queue:Queue.t -> t -> unit
+(** [with_read ~f ~off ~length ~queue channel] performs an asynchronous read of
+    [channel] using the [handler] to deal with data returned which is scheduled
+    onto [queue] *)
+
+val with_write :
+  f:handler -> off:int -> data:Data.t -> queue:Queue.t -> t -> unit
+(** [with_read ~f ~off ~data ~queue channel] performs an asynchronous write to
+    [channel] using the [handler] to deal with data returned which is scheduled
+    onto [queue] *)
 
 val write : Queue.t -> t -> int -> Group.t -> Data.t -> unit
 val set_high_water : t -> int -> unit

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,4 +1,8 @@
 let () =
+  let group = Dispatch.Group.create () in
+  Dispatch.Group.enter group;
+  Dispatch.Group.leave group;
+  Dispatch.Group.wait group (Dispatch.Time.forever ()) |> ignore;
   let block1 = Dispatch.Block.create (fun () -> print_endline "Hello") in
   let block2 = Dispatch.Block.create (fun () -> print_endline "World") in
   Dispatch.Block.exec block1;


### PR DESCRIPTION
This PR abstracts the type of io handlers to a function that can be passed to both `with_read` and `with_write`. These functions are more general and don't do anything related with dispatch groups. 