### PR TITLE
implement simple cat function

### DIFF
--- a/bench/dispatchcat.ml
+++ b/bench/dispatchcat.ml
@@ -1,47 +1,23 @@
-open Dispatch
+(* Inspired by https://github.com/ocaml-multicore/ocaml-uring/blob/main/tests/urcat.ml thanks @avsm *)
 
-(* cat(1) built with g.c.dispatch.
-  Copied from https://github.com/ocaml-multicore/ocaml-uring/blob/main/tests/urcat.ml thanks @avsm *)
-let block_size = 1024
-
-let get_file_size fd =
-  Unix.handle_unix_error Unix.fstat fd |> fun { Unix.st_size; _ } -> st_size
-
-let get_completion_and_print uring =
-  let iov, len =
-    match Uring.wait uring with Some v -> v | None -> failwith "retry"
-  in
-  let bufs = Uring.Iovec.bufs iov in
-  let remaining = ref len in
-  Printf.eprintf "%d bytes read\n%!" len;
-  Array.iter
-    (fun buf ->
-      let buflen = Bigstringaf.length buf in
-      if !remaining > 0 then
-        if buflen <= !remaining then (
-          print_string (Bigstringaf.to_string buf);
-          remaining := !remaining - buflen )
-        else (
-          print_string (Bigstringaf.substring ~off:0 ~len:!remaining buf);
-          remaining := 0 ))
-    bufs
-
-let submit_read_request fname uring =
-  let fd = Unix.(handle_unix_error (openfile fname [ O_RDONLY ]) 0) in
-  let file_sz = get_file_size fd in
-  let blocks =
-    if file_sz mod block_size <> 0 then (file_sz / block_size) + 1
-    else file_sz / block_size
-  in
-  let bufs = Array.init blocks (fun _ -> Uring.Iovec.alloc_buf block_size) in
-  let iov = Uring.Iovec.alloc bufs in
-  let _ = Uring.readv uring fd iov (iov :> Uring.Iovec.t) in
-  let numreq = Uring.submit uring in
-  assert (numreq = 1);
-  ()
+let cat ~group fd =
+  let queue = Dispatch.Queue.create () in
+  let io = Dispatch.Io.create Stream fd queue in
+  let stdout = Dispatch.Io.create Stream Unix.stdout queue in
+  Dispatch.Group.enter group;
+  Dispatch.Io.with_read ~off:0 ~length:max_int ~queue
+    ~f:(fun ~err:_ ~finished data ->
+      if finished then Dispatch.Group.leave group
+      else
+        ( Dispatch.Group.enter group;
+          Dispatch.Io.with_write ~off:0 ~data ~queue
+            ~f:(fun ~err:_ ~finished:_ _ -> Dispatch.Group.leave group) )
+          stdout)
+    io
 
 let () =
   let fname = Sys.argv.(1) in
-  let uring = Uring.create ~queue_depth:1 ~default:Uring.Iovec.empty () in
-  submit_read_request fname uring;
-  get_completion_and_print uring
+  let group = Dispatch.Group.create () in
+  let fd = Unix.(openfile fname [ O_RDONLY ]) 0 in
+  cat ~group fd;
+  Dispatch.(Group.wait group (Time.forever ()) |> ignore)

--- a/bench/dune
+++ b/bench/dune
@@ -6,8 +6,20 @@
 (executable
  (name dispatchcp)
  (modules dispatchcp)
- (libraries cmdliner dispatchcp_lib fmt logs logs.cli logs.fmt fmt.tty
-   fmt.cli))
+ (libraries
+  cmdliner
+  dispatchcp_lib
+  fmt
+  logs
+  logs.cli
+  logs.fmt
+  fmt.tty
+  fmt.cli))
+
+(executable
+ (name dispatchcat)
+ (modules dispatchcat)
+ (libraries dispatch))
 
 (executable
  (name lwtcp)
@@ -24,5 +36,11 @@
  (public_name dispatch-bench)
  (package dispatch-bench)
  (modules cptest)
- (libraries dispatchcp_lib lwtcp_lib dispatch bos bechamel notty.unix
-   bechamel-notty))
+ (libraries
+  dispatchcp_lib
+  lwtcp_lib
+  dispatch
+  bos
+  bechamel
+  notty.unix
+  bechamel-notty))

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,5 @@
+; Copying File
+
 (rule
  (alias runtest)
  (deps text.txt ../bench/dispatchcp.exe)
@@ -10,6 +12,25 @@
  (alias runtest)
  (action
   (diff ./text.txt ./text2.txt)))
+
+; Cat-ing File 
+
+(rule
+ (alias runtest)
+ (deps text.txt ../bench/dispatchcat.exe)
+ (targets text3.txt)
+ (action
+  (progn
+   (with-stdout-to
+    text3.txt
+    (run ../bench/dispatchcat.exe ./text.txt)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ./text.txt ./text3.txt)))
+
+; Testing random parts of the API
 
 (test
  (name main)


### PR DESCRIPTION
The `bench` directory now contains a `dispatchcat.ml` file which mimics the `cat` program by taking a file name and writing its contents to `stdout`. 

Very rudimentary benchmarking shows that it is a little slower than normal `cat`:

```sh
dd if=/dev/urandom of=temp_10GB_file bs=1 count=0 seek=10g

time cat temp_10GB_file > /dev/null
cat temp_10GB_file > /dev/null  0.05s user 3.26s system 91% cpu 3.596 total

time _build/default/bench/dispatchcat.exe temp_10GB_file > /dev/null
_build/default/bench/dispatchcat.exe temp_10GB_file > /dev/nul  0.31s user 3.44s system 106% cpu 3.537 total
```