### PR TITLE
add more data functions

### DIFF
--- a/lib/data.ml
+++ b/lib/data.ml
@@ -6,7 +6,7 @@ type buff =
 external dispatch_data_create : buff -> t = "ocaml_dispatch_data_create"
 external dispatch_data_empty : unit -> t = "ocaml_dispatch_data_empty"
 external dispatch_data_size : t -> int = "ocaml_dispatch_data_size"
-
+external dispatch_data_concat : t -> t -> t = "ocaml_dispatch_concat"
 external dispatch_data_apply : (t -> 'b) -> t -> 'b
   = "ocaml_dispatch_data_apply"
 
@@ -14,3 +14,4 @@ let create = dispatch_data_create
 let empty = dispatch_data_empty
 let size = dispatch_data_size
 let apply f t = dispatch_data_apply f t
+let concat t1 t2 = dispatch_data_concat t1 t2

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -1,0 +1,24 @@
+type t
+(** Dispatch data objects *)
+
+type buff =
+  (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
+(** A buffer to create a data object from *)
+
+val create : buff -> t 
+(** [create buff] creates a new data object from [buff] *)
+
+val empty : unit -> t 
+(** [empty ()] returns an empty data object *)
+
+val size : t -> int 
+(** [size data] returns the size of the data object *)
+
+val apply : (t -> unit) -> t -> unit
+(** [apply f t] applies [f] to [t] using the {{: https://developer.apple.com/documentation/dispatch/1452852-dispatch_data_apply?language=objc} dispatch_data_apply}
+    function. Crucially, if the underlying memory of the data object is non-contiguous 
+    then the function is applied to each individual data object that makes up the larger one. *)
+
+val concat : t -> t -> t 
+(** [concat t1 t2] creates a new [t3] by concating [t1] and [t2] -- note the data of [t3]
+    is non-contiguous so this operation should be fast *)

--- a/lib/dispatch_stubs.c
+++ b/lib/dispatch_stubs.c
@@ -337,6 +337,17 @@ value ocaml_dispatch_data_size(value v_data)
   CAMLreturn(Val_int(dispatch_data_get_size(Data_val(v_data))));
 }
 
+value ocaml_dispatch_concat(value v_d1, value v_d2)
+{
+  // Free these?
+  CAMLparam2(v_d1, v_d2);
+  CAMLlocal1(v_d3);
+  dispatch_data_t d3 = dispatch_data_create_concat(Data_val(v_d1), Data_val(v_d2));
+  v_d3 = caml_alloc_custom(&queue_ops, sizeof(dispatch_data_t), 0, 1);
+  Data_val(v_d3) = d3;
+  CAMLreturn(v_d3);
+}
+
 value ocaml_dispatch_data_apply(value v_f, value v_data)
 {
   CAMLparam2(v_f, v_data);
@@ -346,9 +357,9 @@ value ocaml_dispatch_data_apply(value v_f, value v_data)
     value d = caml_alloc_custom(&queue_ops, sizeof(dispatch_data_t), 0, 1);
     Data_val(d) = region;
     caml_callback_exn(*m_f, d);
-    free_callback(m_f);
     return (_Bool) true;
   });
+  free_callback(m_f);
   CAMLreturn(Val_unit);
 }
 

--- a/test/dune
+++ b/test/dune
@@ -34,4 +34,4 @@
 
 (test
  (name main)
- (libraries dispatch))
+ (libraries cstruct dispatch))

--- a/test/main.ml
+++ b/test/main.ml
@@ -6,4 +6,8 @@ let () =
   let block1 = Dispatch.Block.create (fun () -> print_endline "Hello") in
   let block2 = Dispatch.Block.create (fun () -> print_endline "World") in
   Dispatch.Block.exec block1;
-  Dispatch.Block.exec block2
+  Dispatch.Block.exec block2;
+  let d1 = Dispatch.Data.create (Cstruct.to_bigarray (Cstruct.of_string "hello1")) in 
+  let d2 = Dispatch.Data.create (Cstruct.to_bigarray (Cstruct.of_string "hello2")) in 
+  let d3 = Dispatch.Data.concat d1 d2 in 
+  Dispatch.Data.apply (fun d -> print_int (Dispatch.Data.size d)) d3


### PR DESCRIPTION
This PR fixes the `Data.apply` function and adds `Data.concat` for joining data objects non-contiguously