### PR TITLE
add to_buff and subrange functionality for dispatch data objects

### DIFF
--- a/lib/data.ml
+++ b/lib/data.ml
@@ -7,6 +7,8 @@ external dispatch_data_create : buff -> t = "ocaml_dispatch_data_create"
 external dispatch_data_empty : unit -> t = "ocaml_dispatch_data_empty"
 external dispatch_data_size : t -> int = "ocaml_dispatch_data_size"
 external dispatch_data_concat : t -> t -> t = "ocaml_dispatch_concat"
+external dispatch_data_to_ba : int -> int -> t -> buff = "ocaml_dispatch_data_to_ba"
+external dispatch_data_sub : int -> int -> t -> t = "ocaml_dispatch_data_sub"
 external dispatch_data_apply : (t -> 'b) -> t -> 'b
   = "ocaml_dispatch_data_apply"
 
@@ -15,3 +17,5 @@ let empty = dispatch_data_empty
 let size = dispatch_data_size
 let apply f t = dispatch_data_apply f t
 let concat t1 t2 = dispatch_data_concat t1 t2
+let to_buff ~offset len t = dispatch_data_to_ba offset len t
+let sub = dispatch_data_sub

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -22,3 +22,9 @@ val apply : (t -> unit) -> t -> unit
 val concat : t -> t -> t 
 (** [concat t1 t2] creates a new [t3] by concating [t1] and [t2] -- note the data of [t3]
     is non-contiguous so this operation should be fast *)
+
+val to_buff : offset:int -> int -> t -> buff 
+(** [to_buff t] returns the data as a {! buff} *)
+
+val sub : int -> int -> t -> t 
+(** [sub off len t] returns a new data object consisting of a portion of another's memory region *)

--- a/lib/dispatch_stubs.c
+++ b/lib/dispatch_stubs.c
@@ -330,6 +330,38 @@ value ocaml_dispatch_data_create(value v_ba)
   CAMLreturn(v_empty);
 }
 
+value ocaml_dispatch_data_to_ba(value v_off, value v_len, value v_data) {
+  CAMLparam3(v_off, v_len, v_data);
+  dispatch_data_t dispersed_data = Data_val(v_data);
+  // Copies all of the segments to one contiguous one
+  const void *buff = NULL;
+  size_t size = 0;
+  dispatch_data_t data = dispatch_data_create_map(dispersed_data, &buff, &size);
+  // Copy contents of buff into the big array 
+  void *dest = caml_stat_alloc(size);
+  void *copy = memcpy(dest, buff, size);
+
+  CAMLlocal1(v_ba);
+  long dims[1];
+  dims[0] = size;
+  // Is this right?
+  v_ba = caml_ba_alloc(CAML_BA_CHAR | CAML_BA_C_LAYOUT, 1, copy, dims);
+
+  CAMLreturn(v_ba);
+}
+
+value ocaml_dispatch_data_sub(value v_off, value v_len, value v_data) {
+  CAMLparam3(v_off, v_len, v_data);
+  CAMLlocal1(v_new_data);
+
+  dispatch_data_t new_data = dispatch_data_create_subrange(Data_val(v_data), Int_val(v_off), Int_val(v_len));
+
+  v_new_data = caml_alloc_custom(&queue_ops, sizeof(dispatch_data_t), 0, 1);
+  Data_val(v_new_data) = new_data;
+
+  CAMLreturn(v_new_data);
+}
+
 value ocaml_dispatch_data_empty(value unit)
 {
   CAMLparam1(unit);

--- a/test/dune
+++ b/test/dune
@@ -34,4 +34,4 @@
 
 (test
  (name main)
- (libraries cstruct dispatch))
+ (libraries dispatch))


### PR DESCRIPTION
This PR adds `to_ba` and `sub` functions to `Dispatch.Data` which turns a dispatch data object into a big array and creates a view on the data respectively. 