### PR TITLE
fix dispatch sync and build rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,30 @@
 name: Tests for dispatch
-on: 
+on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request: {}
 jobs:
   test:
     strategy:
       matrix:
-        operating-system: [ macos-latest ]
-        ocaml-version: [ 4.12.0 ]
+        operating-system: [macos-latest]
+        ocaml-version: [4.12.0]
     runs-on: ${{ matrix.operating-system }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: avsm/setup-ocaml@v1
-      with:
-        ocaml-version: ${{ matrix.ocaml-version }}
-    - name: Pinning Package
-      run: opam pin add -yn dispatch.dev './' && opam pin add -yn dispatch-bench.dev './'
-    - name: Packages
-      run: opam depext -yt dispatch.dev && opam depext -yt dispatch-bench.dev
-    - name: Dependencies
-      run: opam install -t -y . --deps-only
-    - name: Building, Installing and Testing
-      run: opam exec -- dune build @install @runtest
-    - name: File copying test
-      run: opam exec -- dune exec ./bench/cptest.exe
+      - uses: actions/checkout@v2
+      - uses: avsm/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ matrix.ocaml-version }}
+      - name: Pinning Package
+        run: opam pin add -yn dispatch.dev './' && opam pin add -yn dispatch-bench.dev './'
+      - name: Packages
+        run: opam depext -yt dispatch.dev && opam depext -yt dispatch-bench.dev
+      - name: Dependencies
+        run: opam install -t -y . --deps-only
+      - name: Building, Installing and Testing
+        run: |
+          opam exec -- dune build 
+          opam exec -- dune install
+          opam exec -- dune runtest
+      - name: File copying test
+        run: opam exec -- dune exec ./bench/cptest.exe

--- a/README.md
+++ b/README.md
@@ -5,3 +5,116 @@ ocaml-dispatch -- bindings to Apple's Grand Central Dispatch
 These are OCaml bindings for Apple's Grand Central Dispatch (GCD) library.
 
 This project is heavily influenced by [ocaml-uring](https://github.com/ocaml-multicore/ocaml-uring/). In particular the copying tests (framework and `lwtcp`) are taken directly from that repository. (TODO: attribute this properly in the code).
+
+## Usage
+
+```ocaml
+# #require "dispatch"
+```
+
+GCD uses queues to handle asynchronous and concurrent code. Pushing items of work to a queue and adding a handler to be called upon completion typically on a different thread.
+
+```ocaml
+# let q = Dispatch.Queue.create ()
+val q : Dispatch.Queue.t = <abstr>
+```
+
+We can submit things to do to `q` asynchronously using `Dispatch.async`, this will not block, so will exit before anything happens! To prevent this, we can enqueue a synchronous call after an async call which *does* block until the completion handler is called. 
+
+```ocaml
+# Dispatch.async q (fun () -> print_endline "Hello");
+  Dispatch.sync q (fun () -> print_endline "World")
+Hello
+World
+- : unit = ()
+```
+
+Now in actual fact nothing particularly concurrent is happening here. OCaml has a single-threaded runtime, so any callback will have to register itself with the runtime and acquire the runtime lock. Where this does help is with async IO because the actual reads and writes which typically block on IO can be done truly asynchronously and it is only our completion handlers that need to do the runtime acquiring dance.
+
+First a helper function which takes a function which returns a `Dispatch.Group.t` (a semaphore-like data-structure). We will wait indefinitely for this group to be left.
+
+```ocaml
+# let with_group f =  
+    Dispatch.Group.wait (f ()) (Dispatch.Time.forever ()) |> ignore
+val with_group : (unit -> Dispatch.Group.t) -> unit = <fun>
+```
+
+Next a copy function, for every `read` of data we also `write` that data out.
+
+```ocaml
+# let cp in_io out_io () = 
+    let group = Dispatch.Group.create () in 
+      Dispatch.Group.enter group;
+      Dispatch.Io.with_read 
+        ~off:0 ~length:max_int ~queue:q 
+          ~f:(fun ~err:_ ~finished data -> 
+              if finished then Dispatch.Group.leave group
+              else (
+                Dispatch.Group.enter group;
+                Dispatch.Io.with_write ~off:0 ~data ~queue:q
+                  ~f:(fun ~err:_ ~finished:_ _ -> Dispatch.Group.leave group)
+                out_io)) in_io;
+      group
+val cp : Dispatch.Io.t -> Dispatch.Io.t -> unit -> Dispatch.Group.t = <fun>
+```
+
+Next we run the function using the `dune-project` and printing to standard out.
+
+```ocaml
+# let () = 
+    let in_io = Dispatch.Io.create Stream (Unix.(openfile "dune-project" [ O_RDONLY ]) 0) q in 
+    let out_io = Dispatch.Io.create Stream Unix.stdout q in
+      with_group (cp in_io out_io)
+(lang dune 2.7)
+
+(name dispatch)
+
+(generate_opam_files true)
+
+(source
+ (github patricoferris/ocaml-dispatch))
+
+(license ISC)
+
+(authors "Patrick Ferris")
+
+(maintainers "pf341@patricoferris.com")
+
+(package
+ (name dispatch)
+ (synopsis "OCaml bindings for Apple's Grand Central Dispatch")
+ (description "Bindings for Apple's Grand Central Dispatch.")
+ (depends
+  (dune-configurator
+   (>= 2.7.1))
+  (logs :with-test)
+  (mdx :with-test)
+  (fmt :with-test)
+  (cmdliner :with-test)))
+
+(package
+ (name dispatch-bench)
+ (synopsis "Small benchmarks for GCD")
+ (description
+  "A package for testing various GCD programs and counter parts written in other libraries.")
+ (depends
+  (notty
+   (>= 0.2.2))
+  (lwt
+   (>= 5.4.0))
+  (logs
+   (>= 0.7.0))
+  (fmt
+   (>= 0.8.9))
+  (cmdliner
+   (>= 1.0.4))
+  (bos
+   (>= 0.2.0))
+  (bechamel-notty
+   (>= 0.1.0))
+  (bechamel
+   (>= 0.1.0))
+  dispatch))
+
+(using mdx 0.1)
+```

--- a/bench/dune
+++ b/bench/dune
@@ -6,15 +6,8 @@
 (executable
  (name dispatchcp)
  (modules dispatchcp)
- (libraries
-  cmdliner
-  dispatchcp_lib
-  fmt
-  logs
-  logs.cli
-  logs.fmt
-  fmt.tty
-  fmt.cli))
+ (libraries cmdliner dispatchcp_lib fmt logs logs.cli logs.fmt fmt.tty
+   fmt.cli))
 
 (executable
  (name dispatchcat)
@@ -36,11 +29,5 @@
  (public_name dispatch-bench)
  (package dispatch-bench)
  (modules cptest)
- (libraries
-  dispatchcp_lib
-  lwtcp_lib
-  dispatch
-  bos
-  bechamel
-  notty.unix
-  bechamel-notty))
+ (libraries dispatchcp_lib lwtcp_lib dispatch bos bechamel notty.unix
+   bechamel-notty))

--- a/dispatch.opam
+++ b/dispatch.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.7"}
   "dune-configurator" {>= "2.7.1"}
   "logs" {with-test}
+  "mdx" {with-test}
   "fmt" {with-test}
   "cmdliner" {with-test}
   "odoc" {with-doc}

--- a/dune
+++ b/dune
@@ -1,0 +1,2 @@
+(mdx
+ (files README.md))

--- a/dune-project
+++ b/dune-project
@@ -1,31 +1,52 @@
 (lang dune 2.7)
+
 (name dispatch)
+
 (generate_opam_files true)
-(source (github patricoferris/ocaml-dispatch))
+
+(source
+ (github patricoferris/ocaml-dispatch))
+
 (license ISC)
+
 (authors "Patrick Ferris")
+
 (maintainers "pf341@patricoferris.com")
+
 (package
  (name dispatch)
  (synopsis "OCaml bindings for Apple's Grand Central Dispatch")
  (description "Bindings for Apple's Grand Central Dispatch.")
  (depends
-  (dune-configurator (>= 2.7.1))
+  (dune-configurator
+   (>= 2.7.1))
   (logs :with-test)
+  (mdx :with-test)
   (fmt :with-test)
   (cmdliner :with-test)))
+
 (package
  (name dispatch-bench)
  (synopsis "Small benchmarks for GCD")
  (description
   "A package for testing various GCD programs and counter parts written in other libraries.")
  (depends
-  (notty (>= 0.2.2))
-  (lwt (>= 5.4.0))
-  (logs (>= 0.7.0))
-  (fmt (>= 0.8.9))
-  (cmdliner (>= 1.0.4))
-  (bos (>= 0.2.0))
-  (bechamel-notty (>= 0.1.0))
-  (bechamel (>= 0.1.0))
+  (notty
+   (>= 0.2.2))
+  (lwt
+   (>= 5.4.0))
+  (logs
+   (>= 0.7.0))
+  (fmt
+   (>= 0.8.9))
+  (cmdliner
+   (>= 1.0.4))
+  (bos
+   (>= 0.2.0))
+  (bechamel-notty
+   (>= 0.1.0))
+  (bechamel
+   (>= 0.1.0))
   dispatch))
+
+(using mdx 0.1)

--- a/lib/config/discover.ml
+++ b/lib/config/discover.ml
@@ -1,18 +1,9 @@
 module C = Configurator.V1
 
 let () =
-  C.main ~name:"foo" (fun c ->
+  C.main ~name:"foo" (fun _c ->
       let conf : C.Pkg_config.package_conf =
-        {
-          libs =
-            [
-              "-L" ^ C.ocaml_config_var_exn c "standard_library";
-              "-lthreadsnat";
-              "-lunix";
-              "-lobjc";
-            ];
-          cflags = [];
-        }
+        { libs = [ "-lobjc" ]; cflags = [] }
       in
       C.Flags.write_sexp "c_flags.sexp" conf.cflags;
       C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -7,8 +7,12 @@ external dispatch_data_create : buff -> t = "ocaml_dispatch_data_create"
 external dispatch_data_empty : unit -> t = "ocaml_dispatch_data_empty"
 external dispatch_data_size : t -> int = "ocaml_dispatch_data_size"
 external dispatch_data_concat : t -> t -> t = "ocaml_dispatch_concat"
-external dispatch_data_to_ba : int -> int -> t -> buff = "ocaml_dispatch_data_to_ba"
+
+external dispatch_data_to_ba : int -> int -> t -> buff
+  = "ocaml_dispatch_data_to_ba"
+
 external dispatch_data_sub : int -> int -> t -> t = "ocaml_dispatch_data_sub"
+
 external dispatch_data_apply : (t -> 'b) -> t -> 'b
   = "ocaml_dispatch_data_apply"
 

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -5,26 +5,29 @@ type buff =
   (char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 (** A buffer to create a data object from *)
 
-val create : buff -> t 
+val create : buff -> t
 (** [create buff] creates a new data object from [buff] *)
 
-val empty : unit -> t 
+val empty : unit -> t
 (** [empty ()] returns an empty data object *)
 
-val size : t -> int 
+val size : t -> int
 (** [size data] returns the size of the data object *)
 
 val apply : (t -> unit) -> t -> unit
-(** [apply f t] applies [f] to [t] using the {{: https://developer.apple.com/documentation/dispatch/1452852-dispatch_data_apply?language=objc} dispatch_data_apply}
-    function. Crucially, if the underlying memory of the data object is non-contiguous 
-    then the function is applied to each individual data object that makes up the larger one. *)
+(** [apply f t] applies [f] to [t] using the
+    {{:https://developer.apple.com/documentation/dispatch/1452852-dispatch_data_apply?language=objc}
+    dispatch_data_apply} function. Crucially, if the underlying memory of the
+    data object is non-contiguous then the function is applied to each
+    individual data object that makes up the larger one. *)
 
-val concat : t -> t -> t 
-(** [concat t1 t2] creates a new [t3] by concating [t1] and [t2] -- note the data of [t3]
-    is non-contiguous so this operation should be fast *)
+val concat : t -> t -> t
+(** [concat t1 t2] creates a new [t3] by concating [t1] and [t2] -- note the
+    data of [t3] is non-contiguous so this operation should be fast *)
 
-val to_buff : offset:int -> int -> t -> buff 
-(** [to_buff t] returns the data as a {! buff} *)
+val to_buff : offset:int -> int -> t -> buff
+(** [to_buff t] returns the data as a {!buff} *)
 
-val sub : int -> int -> t -> t 
-(** [sub off len t] returns a new data object consisting of a portion of another's memory region *)
+val sub : int -> int -> t -> t
+(** [sub off len t] returns a new data object consisting of a portion of
+    another's memory region *)

--- a/lib/dispatch_stubs.c
+++ b/lib/dispatch_stubs.c
@@ -137,19 +137,20 @@ value ocaml_dispatch_sync(value v_queue, value v_fun)
   caml_release_runtime_system();
   dispatch_sync(queue, ^{
     int res = caml_c_thread_register();
-
-    if (res)
-      caml_acquire_runtime_system();
+    // printf("RES %i\n", res);
+    caml_acquire_runtime_system();
 
     caml_callback(*m_fun, Val_unit);
 
+    caml_release_runtime_system();
+    
     if (res)
     {
-      caml_release_runtime_system();
       caml_c_thread_unregister();
     }
     return;
   });
+  caml_acquire_runtime_system();
   CAMLreturn(Val_unit);
 }
 

--- a/lib/dune
+++ b/lib/dune
@@ -3,24 +3,13 @@
  (public_name dispatch)
  (c_library_flags
   (:include c_library_flags.sexp))
- (flags
-  (:standard -thread))
- (libraries threads)
+ (libraries threads bigarray)
  (foreign_stubs
   (language c)
   (flags
-   (:standard
-    -O
-    -g
-    -std=c99
-    -pedantic-errors
-    -Wsign-compare
-    -Wshadow
-    -Wno-unguarded-availability-new
-    -Wc11-extensions
-    -mmacosx-version-min=10.10
-    -x
-    objective-c))
+   (:standard -O -g -std=c99 -pedantic-errors -Wsign-compare -Wshadow
+     -Wno-unguarded-availability-new -Wc11-extensions
+     -mmacosx-version-min=10.10 -x objective-c))
   (names dispatch_stubs)))
 
 (rule

--- a/test/dune
+++ b/test/dune
@@ -31,7 +31,9 @@
   (diff ./text.txt ./text3.txt)))
 
 ; Testing random parts of the API
+; running in byte mode seems to hit different code paths
 
 (test
  (name main)
+ (modes byte)
  (libraries dispatch))

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,4 +1,10 @@
-let () =
+(* GC Tests *)
+let queue () =
+  let q = Dispatch.Queue.create () in
+  Dispatch.async q (fun () -> print_endline "Hello");
+  Dispatch.sync q (fun () -> print_endline "World")
+
+let random () =
   let group = Dispatch.Group.create () in
   Dispatch.Group.enter group;
   Dispatch.Group.leave group;
@@ -8,7 +14,8 @@ let () =
   Dispatch.Block.exec block1;
   Dispatch.Block.exec block2
 
-(* let d1 = Dispatch.Data.create (Cstruct.to_bigarray (Cstruct.of_string "hello1")) in
-   let d2 = Dispatch.Data.create (Cstruct.to_bigarray (Cstruct.of_string "hello2")) in
-   let d3 = Dispatch.Data.concat d1 d2 in
-   Dispatch.Data.apply (fun d -> print_int (Dispatch.Data.size d)) d3 *)
+let main () =
+  queue ();
+  random ()
+
+let () = main ()


### PR DESCRIPTION
This PR:
 - Fixes the `Dispatch.sync` function, running a simple test-case using bytecode showed that the runtime acquiring and releasing wasn't quite right
 - Also tries to fix the build rules for linking threads etc.
 - Adds a small example to the README