### PR TITLE
add simple C cat program

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,63 +58,26 @@ Next a copy function, for every `read` of data we also `write` that data out.
 val cp : Dispatch.Io.t -> Dispatch.Io.t -> unit -> Dispatch.Group.t = <fun>
 ```
 
-Next we run the function using the `dune-project` and printing to standard out.
+Next we run the function using the `LICENSE.md` and printing to standard out.
 
 ```ocaml
 # let () = 
-    let in_io = Dispatch.Io.create Stream (Unix.(openfile "dune-project" [ O_RDONLY ]) 0) q in 
+    let in_io = Dispatch.Io.create Stream (Unix.(openfile "LICENSE.md" [ O_RDONLY ]) 0) q in 
     let out_io = Dispatch.Io.create Stream Unix.stdout q in
       with_group (cp in_io out_io)
-(lang dune 2.7)
-
-(name dispatch)
-
-(generate_opam_files true)
-
-(source
- (github patricoferris/ocaml-dispatch))
-
-(license ISC)
-
-(authors "Patrick Ferris")
-
-(maintainers "pf341@patricoferris.com")
-
-(package
- (name dispatch)
- (synopsis "OCaml bindings for Apple's Grand Central Dispatch")
- (description "Bindings for Apple's Grand Central Dispatch.")
- (depends
-  (dune-configurator
-   (>= 2.7.1))
-  (logs :with-test)
-  (mdx :with-test)
-  (fmt :with-test)
-  (cmdliner :with-test)))
-
-(package
- (name dispatch-bench)
- (synopsis "Small benchmarks for GCD")
- (description
-  "A package for testing various GCD programs and counter parts written in other libraries.")
- (depends
-  (notty
-   (>= 0.2.2))
-  (lwt
-   (>= 5.4.0))
-  (logs
-   (>= 0.7.0))
-  (fmt
-   (>= 0.8.9))
-  (cmdliner
-   (>= 1.0.4))
-  (bos
-   (>= 0.2.0))
-  (bechamel-notty
-   (>= 0.1.0))
-  (bechamel
-   (>= 0.1.0))
-  dispatch))
-
-(using mdx 0.1)
+/*
+ * Copyright (C) 2020-2021 Patrick Ferris
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 ```

--- a/bench/cat.c
+++ b/bench/cat.c
@@ -1,0 +1,52 @@
+#include <dispatch/dispatch.h>
+#include <stdio.h>
+// Pure GCD cat-like program (used to test the overhead of OCaml's runtime)
+
+dispatch_group_t cat(dispatch_fd_t fd) {
+  dispatch_group_t group = dispatch_group_create();
+  dispatch_queue_t queue = dispatch_queue_create("ocaml.rw.queue", DISPATCH_QUEUE_SERIAL);
+  dispatch_io_t in_io = dispatch_io_create(DISPATCH_IO_STREAM, fd, queue, ^(int err){ return; });
+  dispatch_io_t out_io = dispatch_io_create(DISPATCH_IO_STREAM, STDOUT_FILENO, queue, ^(int err){ return; });
+  dispatch_io_set_high_water(in_io, 1024 * 64);
+  dispatch_group_enter(group);
+  dispatch_io_read(in_io, 0, SIZE_MAX, queue,
+    ^(bool done, dispatch_data_t data, int error) {
+      size_t data_size;
+      if (error) {
+        printf("Somethings gone wrong!"); 
+        return;
+      }
+      if (done) {
+        dispatch_group_leave(group);
+      }
+      if (data) {
+        // data_size = dispatch_data_get_size(data);
+        // if (data_size > 0) {
+          dispatch_group_enter(group);
+          dispatch_io_write(out_io, 0, data, queue,
+            ^(bool done, dispatch_data_t data, int error) {
+              if (error) {
+                printf("Something's gone wrong!");
+                return;
+              }
+              if (done) {
+                dispatch_group_leave(group);
+              }
+            }
+          );
+        // }
+      }
+    }
+  );
+
+  return group;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc > 1) {
+    int fd = open(argv[1], O_RDONLY);
+    dispatch_group_wait(cat(fd), DISPATCH_TIME_FOREVER);
+  } else {
+    dispatch_group_wait(cat(STDIN_FILENO), DISPATCH_TIME_FOREVER);
+  }
+}

--- a/bench/dispatchcat.ml
+++ b/bench/dispatchcat.ml
@@ -5,6 +5,7 @@ let cat ~group fd =
   let io = Dispatch.Io.create Stream fd queue in
   let stdout = Dispatch.Io.create Stream Unix.stdout queue in
   Dispatch.Group.enter group;
+  Dispatch.Io.set_high_water io (1024 * 64);
   Dispatch.Io.with_read ~off:0 ~length:max_int ~queue
     ~f:(fun ~err:_ ~finished data ->
       if finished then Dispatch.Group.leave group
@@ -16,8 +17,11 @@ let cat ~group fd =
     io
 
 let () =
-  let fname = Sys.argv.(1) in
   let group = Dispatch.Group.create () in
-  let fd = Unix.(openfile fname [ O_RDONLY ]) 0 in
+  let fd = 
+    if Array.length Sys.argv > 1
+    then Unix.(openfile Sys.argv.(1) [ O_RDONLY ]) 0
+    else Unix.stdin 
+  in
   cat ~group fd;
   Dispatch.(Group.wait group (Time.forever ()) |> ignore)

--- a/bench/dune
+++ b/bench/dune
@@ -31,3 +31,9 @@
  (modules cptest)
  (libraries dispatchcp_lib lwtcp_lib dispatch bos bechamel notty.unix
    bechamel-notty))
+
+(rule
+ (alias default)
+ (deps cat.c)
+ (targets cat)
+ (action (run gcc -O3 -o cat cat.c)))

--- a/test/dune
+++ b/test/dune
@@ -30,6 +30,23 @@
  (action
   (diff ./text.txt ./text3.txt)))
 
+; C cat-ing file
+
+(rule
+ (alias runtest)
+ (deps text.txt ../bench/cat)
+ (targets text4.txt)
+ (action
+  (progn
+   (with-stdout-to
+    text4.txt
+    (run ../bench/cat ./text.txt)))))
+
+(rule
+ (alias runtest)
+ (action
+  (diff ./text.txt ./text4.txt)))
+
 ; Testing random parts of the API
 ; running in byte mode seems to hit different code paths
 


### PR DESCRIPTION
This PR adds a simple C cat program, this can be used to bench mark the OCaml dispatch bindings to pure C ones already this has highlighted a few things. The first and most important; OCaml simply can't use the callback-based approach when running on a `Concurrent` `Dispatch.Queue.t`, this is because the callback will be blocked (waiting for the runtime) and this causes GCD to... "thread explode" 💥 ! Concurrent queues spin up more threads to try and deal with things not finishing whereas `Serial` queues do not. 

One workaround I was thinking about having a look at, is creating an optimised library (tentatively named `dispatchio`) which, instead of allowing users to specify the callback from OCaml, the eio_dispatch approach of submission and completion queue could be used with some data-structure in C that the OCaml code can pull completions off of with the main idea to not block the callbacks happening in other threads... 