### PR TITLE
Add dispatch_io_create_with_path to avoid unix

### DIFF
--- a/lib/io.ml
+++ b/lib/io.ml
@@ -3,8 +3,19 @@ type typ = Stream | Random
 type err = int
 type handler = err:err -> finished:bool -> Data.t -> unit
 
-external dispatch_io_create : typ -> Unix.file_descr -> Queue.t -> t
+module Fd = struct
+  type t = int
+  let stdout = 1
+  let stdin = 0
+
+  let of_unix = Obj.magic
+end
+
+external dispatch_io_create : typ -> int -> Queue.t -> t
   = "ocaml_dispatch_io_create"
+
+external dispatch_io_create_with_path : int -> int -> string -> typ -> Queue.t -> t
+  = "ocaml_dispatch_io_create_with_path"
 
 external dispatch_io_close : t -> unit
   = "ocaml_dispatch_io_close"
@@ -26,7 +37,10 @@ external dispatch_set_high_water : t -> int -> unit
 external dispatch_set_low_water : t -> int -> unit
   = "ocaml_dispatch_set_low_water"
 
-let create typ fd q = dispatch_io_create typ fd q
+let create typ fd queue = dispatch_io_create typ fd queue
+
+let create_with_path ~flags ~mode ~path typ queue =
+  dispatch_io_create_with_path flags mode path typ queue
 
 let close t = dispatch_io_close t
 

--- a/lib/io.mli
+++ b/lib/io.mli
@@ -7,10 +7,19 @@ type typ =
       (** The underlying type of the channel -- with [Random] you can use the
           file offset to read *)
 
-val create : typ -> Unix.file_descr -> Queue.t -> t
-(** Create a new channel of a particular [typ] from a path *)
+module Fd : sig
+  type t
+  val stdout : t
+  val stdin : t
+  (* Would be good to remove *)
+  val of_unix : Unix.file_descr -> t
+end
 
-(* val read : Queue.t -> t -> int -> int -> Group.t -> Data.t -> unit *)
+val create : typ -> Fd.t -> Queue.t -> t
+(** Create a new channel of a particular [typ] from a file descriptor *)
+
+val create_with_path : flags:int -> mode:int -> path:string -> typ -> Queue.t -> t
+(** Create a new channel of a particular [typ] from a path *)
 
 type err = int
 (** Error type *)

--- a/test/dune
+++ b/test/dune
@@ -23,7 +23,7 @@
   (progn
    (with-stdout-to
     text3.txt
-    (run ../bench/dispatchcat.exe ./text.txt)))))
+    (run ../bench/dispatchcat.exe %{workspace_root}/text.txt)))))
 
 (rule
  (alias runtest)


### PR DESCRIPTION
This is a start to trying to remove `Unix` from this library which should be possible. Annoyingly, `dispatch_io_create_with_path` only accepts absolute paths which is not ideal. 